### PR TITLE
Add undo/redo support

### DIFF
--- a/data/history.js
+++ b/data/history.js
@@ -1,0 +1,107 @@
+import { updateButtons } from "../interface/inputs/historyinputs.js";
+
+const MAX_HISTORY = 20;
+let idCounter = 0;
+
+class Node {
+    // Track depth from start of the list so we can evict old nodes
+    constructor(data, prev=null, next=null, depth=0) {
+        this.data = data;
+        this.prev = prev;
+        this.next = next;
+        this.depth = depth;
+        this.id = idCounter;
+
+        idCounter += 1;
+    }
+
+    setPrev(prev) {
+        this.prev = prev;
+        prev.next = this;
+    }
+
+    setNext(next) {
+        this.next = next;
+        next.prev = this;
+    }
+}
+
+let current = null;
+let oldest = null;
+function updateCurrentData(newData) {
+    if (current && current.data === newData) {
+        console.log("Skipping history update because no change was made");
+        return;
+    }
+
+    let oldCurrent = current;
+    current = new Node(newData);
+    console.log("Updating current history node to id", current.id);
+    if (oldCurrent != null) {
+        current.setPrev(oldCurrent);
+        current.depth = oldCurrent.depth + 1;
+        if (current.depth - oldest.depth >= MAX_HISTORY) {
+            console.log(
+                "Evicting history node with id",
+                oldest.id,
+                "because depth",
+                oldest.depth,
+                "is too far behind current depth",
+                current.depth
+            );
+            oldest = oldest.next;
+            // Erase reference to prev so js can garbage collect it
+            oldest.prev = null;
+        }
+    } else {
+        oldest = current;
+    }
+
+    updateButtons();
+}
+
+/**
+ * Step backwards in history if possible and return the new current node
+ * Return null if current.prev is null
+ */
+function stepBackwards() {
+    if (current && current.prev) {
+        current = current.prev;
+        console.log("Stepping back to node", current.id);
+        updateButtons();
+        return current.data
+    } else {
+        return null;
+    }
+}
+
+/**
+ * Step forward in history if possible and return the new current node
+ * Return null if current.next is null
+ */
+function stepForwards() {
+    if (current && current.next) {
+        current = current.next;
+        console.log("Stepping forward to node", current.id);
+        updateButtons();
+        return current.data;
+    } else {
+        return null;
+    }
+}
+
+function hasNext() {
+    return current && current.next;
+}
+
+function hasPrevious() {
+    return current && current.prev;
+}
+
+export default {
+    hasPrevious,
+    hasNext,
+    stepForwards,
+    stepBackwards,
+    updateCurrentData
+}

--- a/index.html
+++ b/index.html
@@ -39,6 +39,11 @@
     </div>
 
     <div id="planner-options">
+        <div id="metacontrols">
+            <button type="button" id="undo" disabled>Undo</button>
+            <button type="button" id="redo" disabled>Redo</button>
+            <button type="button" id="reset">Reset</button>
+        </div>
         <div id="options">
             <label for="pin-type">Pin type</label>
             <select name="pin-type" id="pin-type"></select>
@@ -46,7 +51,6 @@
             <select name="milling-type" id="milling-type"></select>
             <button id="add-pin" class="btn">Add pin</button>
             <button type="button" id="add-chamber">Add chamber</button>
-            <button type="button" id="reset">Reset</button>
 
             <div id="chamber-selected-options">
                 <button type="button" id="simulate-chamber" class="chamber-specific-btn" disabled>Simulate

--- a/interface/inputs/historyinputs.js
+++ b/interface/inputs/historyinputs.js
@@ -1,0 +1,42 @@
+import History from "../../data/history.js";
+import UrlManager from "../urlmanager.js";
+import {setChambers} from "../../main.js";
+
+const undo = document.getElementById("undo");
+const redo = document.getElementById("redo");
+
+export function addHistoryListeners() {
+    undo.addEventListener("click", () => {
+        const newSerChambers = History.stepBackwards();
+        if (newSerChambers) {
+            let newChambers = UrlManager.loadFromString(newSerChambers);
+            setChambers(newChambers);
+            UrlManager.updateUrlParamsRaw(newSerChambers);
+            updateButtons();
+        }
+    });
+
+    redo.addEventListener("click", () => {
+        const newSerChambers = History.stepForwards();
+        if (newSerChambers) {
+            let newChambers = UrlManager.loadFromString(newSerChambers);
+            setChambers(newChambers);
+            UrlManager.updateUrlParamsRaw(newSerChambers);
+            updateButtons();
+        }
+    });
+}
+
+export function updateButtons() {
+    if (History.hasPrevious()) {
+        undo.removeAttribute("disabled");
+    } else {
+        undo.setAttribute("disabled", true);
+    }
+
+    if (History.hasNext()) {
+        redo.removeAttribute("disabled");
+    } else {
+        redo.setAttribute("disabled", true);
+    }
+}

--- a/interface/inputs/inputs.js
+++ b/interface/inputs/inputs.js
@@ -1,9 +1,11 @@
 import { registerChamberListeners } from "./chamberinputs.js";
 import { registerResetListener } from "./reset.js";
 import { registerSimulatorInputs } from "./simulatorinputs.js";
+import { addHistoryListeners } from "./historyinputs.js";
 
 export function registerAllListeners() {
     registerChamberListeners();
     registerResetListener();
     registerSimulatorInputs();
+    addHistoryListeners();
 }

--- a/interface/pineditor.js
+++ b/interface/pineditor.js
@@ -76,7 +76,7 @@ function isPinEditorOpen() {
 }
 
 function selectPoint(point, pointIdx, mirroredPointIdx = null) {
-    console.log("Selected point ", point);
+    console.debug("Selected point ", point);
     selectedNormalizedPoint = point;
     selectedPointIdx = pointIdx;
     selectedMirroredPointIdx = mirroredPointIdx;
@@ -86,7 +86,7 @@ function selectPoint(point, pointIdx, mirroredPointIdx = null) {
 }
 
 function resetPointSelection() {
-    console.log("Resetting point selection");
+    console.debug("Resetting point selection");
     selectedNormalizedPoint = null;
     selectedPointIdx = null;
     selectedMirroredPointIdx = null;
@@ -113,7 +113,7 @@ function handleClick(event) {
     }
 
     if (event.altKey) {
-        console.log("Alt key held");
+        console.debug("Alt key held");
         deleteSelectedPoint();
         return;
     }
@@ -121,7 +121,7 @@ function handleClick(event) {
 
     if (!isExistingPoint) {
         // Need to create a new point
-        console.log("Current points: %d", currentPin.points.length);
+        console.debug("Current points: %d", currentPin.points.length);
         currentPin.points.splice(pointIdx, 0, nearest);
         console.log("Created point at index %d, now points: %d", pointIdx, currentPin.points.length);
         if (mirroredEditor) {
@@ -170,19 +170,19 @@ function handleClick(event) {
 
 function deleteSelectedPoint() {
     if (selectedPointIdx == null) {
-        console.log("Doing nothing since no point selected");
+        console.debug("Doing nothing since no point selected");
         return;
     }
 
     // remove selected point
-    console.log("Removing point at %d", selectedPointIdx);
+    console.debug("Removing point at %d", selectedPointIdx);
     currentPin.points.splice(selectedPointIdx, 1);
     if (selectedMirroredPointIdx) {
         let mirroredIdxToDelete = selectedMirroredPointIdx;
         if (selectedMirroredPointIdx > selectedPointIdx) {
             mirroredIdxToDelete--;
         }
-        console.log("Removing point at %d", mirroredIdxToDelete);
+        console.debug("Removing point at %d", mirroredIdxToDelete);
         currentPin.points.splice(mirroredIdxToDelete, 1);
     }
 
@@ -204,10 +204,10 @@ function handleMouseDown(event) {
         let { nearest, pointIdx, isExistingPoint } = closestPointToPos(normalizedMouseX, normalizedMouseY);
 
         if (pointIdx == selectedPointIdx) {
-            console.log("Mouse down near selected point, beginning drag");
+            console.debug("Mouse down near selected point, beginning drag");
             isDragging = true;
         } else if (pointIdx == selectedMirroredPointIdx) {
-            console.log("Mouse down near mirrored selected point, switching that to be active selected point then beginning drag");
+            console.debug("Mouse down near mirrored selected point, switching that to be active selected point then beginning drag");
             handleClick(event);
             isDragging = true;
         }
@@ -331,7 +331,7 @@ function closestPointToPos(x, y) {
             let qq = (qx * qx) + (qy * qy);
 
             if (qq < nearestNormsqr && qq < .01) {
-                console.log("Checking point ", i, "qq val is ", qq);
+                console.debug("Checking point ", i, "qq val is ", qq);
                 nearest = q
                 nearestNormsqr = qq
                 bestT = t;
@@ -352,13 +352,13 @@ function closestPointToPos(x, y) {
         nearestNormsqr = Number.MAX_VALUE;
     }
 
-    console.log("Nearest point is", nearest, existingPointIdx, isExistingPoint);
+    console.debug("Nearest point is", nearest, existingPointIdx, isExistingPoint);
 
     return { nearest, pointIdx: existingPointIdx, isExistingPoint };
 }
 
 function redraw() {
-    console.log("Redrawing pin editor");
+    console.debug("Redrawing pin editor");
 
     let h = canvas.height - 10;
     const widthToHeightRatio = 4 / currentPin.pinHeight;
@@ -424,13 +424,13 @@ pointY.addEventListener('input', evt => {
     }
 });
 lockDropDown.addEventListener('input', evt => {
-    console.log("Value changed to", evt);
+    console.debug("Value changed to", evt);
     if (selectedNormalizedPoint) {
         let selectedOption = evt.target.selectedOptions[0];
         let newLValue = null;
         if (selectedOption.attributes.lvalue != null) {
             newLValue = parseFloat(selectedOption.attributes.lvalue.value);
-            console.log("New l value ", newLValue, "parsed from ", selectedOption.attributes.lvalue)
+            console.debug("New l value ", newLValue, "parsed from ", selectedOption.attributes.lvalue)
         } else if (selectedOption.value == "custom" && selectedNormalizedPoint.lockRelativeToHeight != null) {
             pointLockCustomValue.value = selectedNormalizedPoint.lockRelativeToHeight;
         }

--- a/interface/renderer.js
+++ b/interface/renderer.js
@@ -90,8 +90,8 @@ function drawChamber(chamber, chamberNum, chamberWidth, chamberHeight) {
 // Pin is an array of points normalized to 1x1 rect
 // Origin starting at bottom left corner
 // will be rescaled to w by h rect at (x, y)
-function drawPin(pin, x, y, w, h) {
-    drawPinPath(pin, x, y, w, h);
+function drawPin(pin, x, y, w, h, updateLastRenderMetadata = true) {
+    drawPinPath(pin, x, y, w, h, updateLastRenderMetadata);
     ctx.fill();
 }
 
@@ -105,7 +105,7 @@ function drawPinPoints(pin, x, y, w, h) {
     });
 }
 
-function drawPinPath(pin, x, y, w, h) {
+function drawPinPath(pin, x, y, w, h, updateLastRenderMetadata = true) {
     ctx.moveTo(x, y);
     ctx.beginPath();
     pin.points.forEach(point => {
@@ -114,12 +114,14 @@ function drawPinPath(pin, x, y, w, h) {
         ctx.lineTo(px, py);
     });
     ctx.closePath();
-    pin.lastRenderMetadata = new DOMRect(x, y, w, h);
+    if (updateLastRenderMetadata) {
+        pin.lastRenderMetadata = new DOMRect(x, y, w, h);
+    }
 }
 
 // Coordinates use bottom left as origin for ease of use
 function findPinUnderCoordinates(chambers, x, y) {
-    console.log("Searching chambers ", chambers, "for coordinates", x, y);
+    console.debug("Searching chambers ", chambers, "for coordinates", x, y);
 
     if (chambers.length == 0) {
         return {};
@@ -138,13 +140,14 @@ function findPinUnderCoordinates(chambers, x, y) {
     for (let pin of chamber.pinStack) {
         let pinRect = pin.lastRenderMetadata;
         if (pinRect.contains(x, y)) {
+            console.debug("Found match, pinrect", pinRect, "does contain", x, y, "from pin", pin);
             foundPin = pin;
             break;
         }
         pinIdx++;
     }
 
-    console.log("Found match: %s, pin: %s", foundPin, pinIdx);
+    console.debug("Found match", foundPin, "pin", pinIdx);
 
     return {chamber, pin:foundPin, pinIdx, chamberIdx};
 }

--- a/interface/urlmanager.js
+++ b/interface/urlmanager.js
@@ -1,34 +1,43 @@
 import Crusher from "../lib/JSONCrush.min.js";
 import {Chamber} from "../models/chamber.js";
+import History from "../data/history.js";
 
 const chambersParam = "c";
 
+function loadFromString(serializedChambers) {
+    try {
+        console.debug("Raw serialized chambers:", serializedChambers);
+        let rawChambers = JSON.parse(Crusher.uncrush(decodeURIComponent(serializedChambers)));
+        console.debug("Raw chambers: " + rawChambers);
+        let chamberIdx = 0;
+        let result = [];
+        rawChambers.forEach(rawChamber => {
+            let chamber = Chamber.deserialize(rawChamber);
+            chamber.chambers = result;
+            chamber.chamberIdx = chamberIdx;
+            let pinIdx = 0;
+            chamber.pinStack.forEach(pin => {
+                pin.chamber = chamber;
+                pin.pinIdx = pinIdx;
+                pinIdx++;
+            });
+
+            result.push(chamber);
+            chamberIdx++;
+        });
+        console.log("Loaded chambers", result);
+        return result;
+    } catch (e) {
+        console.debug("Malformed query param", e);
+        return [];
+    }
+}
+
 function loadFromUrlParams() {
     const params = new URLSearchParams(window.location.search);
-    if (params.get(chambersParam)) {
-        try {
-            let rawChambers = JSON.parse(decodeURIComponent(Crusher.uncrush((params.get(chambersParam)))));
-            console.log("Raw chambers: " + rawChambers);
-            let chamberIdx = 0;
-            let result = [];
-            rawChambers.forEach(rawChamber => {
-                let chamber = Chamber.deserialize(rawChamber);
-                chamber.chambers = result;
-                chamber.chamberIdx = chamberIdx;
-                let pinIdx = 0;
-                chamber.pinStack.forEach(pin => {
-                    pin.chamber = chamber;
-                    pin.pinIdx = pinIdx;
-                    pinIdx++;
-                });
-
-                result.push(chamber);
-                chamberIdx++;
-            });
-            return result;
-        } catch (e) {
-            console.log("Malformed query param", e);
-        }
+    const serializedChambers = params.get(chambersParam);
+    if (serializedChambers) {
+        return loadFromString(serializedChambers);
     }
     return [];
 }
@@ -37,6 +46,15 @@ function updateUrlParams(chambers) {
     let serializedChambers = encodeURIComponent(Crusher.crush(JSON.stringify(chambers.map(c => c.serialize()))));
     let newUrl = window.location.origin + window.location.pathname + "?c=" + serializedChambers;
     window.history.replaceState({path:newUrl}, "", newUrl);
+    History.updateCurrentData(serializedChambers);
 }
 
-export default {loadFromUrlParams, updateUrlParams};
+/**
+ * Used to update the url params in the browser after moving around in history
+ */
+function updateUrlParamsRaw(serializedChambers) {
+    let newUrl = window.location.origin + window.location.pathname + "?c=" + serializedChambers;
+    window.history.replaceState({path:newUrl}, "", newUrl);
+}
+
+export default {updateUrlParamsRaw, loadFromUrlParams, updateUrlParams, loadFromString};

--- a/main.js
+++ b/main.js
@@ -21,6 +21,11 @@ let selectedChamber, selectedPin;
 let mouseDownX, mouseDownY;
 let dragging = false;
 
+export function setChambers(newChambers) {
+    chambers = newChambers;
+    redraw();
+}
+
 export function addChamber(chamber) {
     const idx = chambers.push(chamber) - 1;
     chamber.chambers = chambers;
@@ -52,7 +57,7 @@ function setCanvasSize() {
     // Having pin points use bottom left origin and canvas us top left origin is annoying
     // Just use bottom left origin for everything
     ctx.transform(1, 0, 0, -1, 0, canvas.height)
-    console.log("resizing");
+    console.debug("resizing");
     redraw();
     if (PinEditor.isPinEditorOpen()) {
         PinEditor.redraw();
@@ -121,7 +126,7 @@ function handleClick(event) {
     if (Simulator.isOpen()) {
         return;
     }
-    console.log("click");
+    console.debug("click");
     if (PinEditor.isPinEditorOpen()) {
         PinEditor.handleClick(event);
         return;
@@ -217,7 +222,7 @@ canvas.addEventListener("mousemove", event => {
                 const mouseY = canvasBounds.height - (event.clientY - canvasBounds.top);
                 redraw();
                 ctx.fillStyle = "#aaae";
-                drawPin(selectedPin, mouseX - 25, mouseY, 50, 50 * selectedPin.pinHeight / chamberHeightToWidthRatio);
+                drawPin(selectedPin, mouseX - 25, mouseY, 50, 50 * selectedPin.pinHeight / chamberHeightToWidthRatio, false);
             } else if (!dragging) {
                 // Make sure clicks don't register as drags
                 if (Math.max(Math.abs(event.clientX - mouseDownX), Math.abs(event.clientY - mouseDownY) > 10)) {
@@ -286,7 +291,6 @@ document.getElementById("decrease-pin-height").addEventListener("click", () => {
 });
 
 document.getElementById("mirrored-editor").addEventListener("change", event => {
-    console.log(event);
     PinEditor.setMirroredEditor(event.target.checked);
 });
 
@@ -346,7 +350,6 @@ function onPinEditorExit() {
 }
 
 export function redraw() {
-    console.log("Redrawing chambers");
     redrawChambers(chambers);
 }
 
@@ -374,6 +377,7 @@ export function simulateSelectedChamber() {
 }
 
 chambers = UrlManager.loadFromUrlParams();
+UrlManager.updateUrlParams(chambers);
 redraw();
 
 // Populate pintype options from our json data

--- a/models/chamber.js
+++ b/models/chamber.js
@@ -10,7 +10,7 @@ export const MillingType = {
 }
 
 export class Chamber {
-    constructor(pinStack = [], millingType=MillingType.Gin) {
+    constructor(pinStack = [], millingType=MillingType.None) {
         this.millingType = millingType;
         this.pinStack = pinStack;
         this.lastRenderMetadata = null;
@@ -141,7 +141,6 @@ export class Chamber {
             let point = points[i];
             points.push(new Point(outerWidth - point.x, point.y, point.lockRelativeToHeight));
         }
-        console.log("raw core points", points);
         return points;
     }
 

--- a/models/pin.js
+++ b/models/pin.js
@@ -25,8 +25,8 @@ export class Pin {
     }
 
     serialize() {
-        console.log("Serializing points", this.points);
-        console.log("Plain serialization", JSON.stringify(this.points));
+        console.debug("Serializing points", this.points);
+        console.debug("Plain serialization", JSON.stringify(this.points));
         return JSON.stringify({ points: this.points.map(p => p.objToSerialize()), pinHeight: this.pinHeight },
             (key, val) =>
                 (val && val.toFixed) ? Number(val.toFixed(4)) : val

--- a/models/pinfactory.js
+++ b/models/pinfactory.js
@@ -7,13 +7,13 @@ const NAMED_PIN_PREFIXES = new Map(Object.entries(PinTypes)
     .map((entry) => [entry[1].serializationPrefix, entry[0]]));
 
 function fromClass(pinClassName, pinHeight) {
-    console.log("Creating from class name", pinClassName);
+    console.debug("Creating from class name", pinClassName);
     // Just hope it works lol, who cares about type safety anyway
     return new JSONPremadePin(pinHeight, PinTypes[pinClassName]);
 }
 
 function keyPin(pinHeight) {
-    console.log(PinTypes.KeyPin);
+    console.debug(PinTypes.KeyPin);
     return new JSONPremadePin(pinHeight, PinTypes.KeyPin);
 }
 
@@ -22,28 +22,28 @@ function standardDriver(pinHeight) {
 }
 
 function deserialize(strPoints) {
-    console.log("Raw points: " + strPoints);
+    console.debug("Raw points: " + strPoints);
     if (strPoints.startsWith("{")) {
         // it's a raw pin
         try {
             let obj = JSON.parse(strPoints);
-            console.log("Parsed object", obj);
+            console.debug("Parsed object", obj);
             obj.points = obj.points.map(point => Point.fromRawObj(point));
             return Object.assign(new Pin([], 0), obj);
         } catch (e) {
-            console.log("Unable to deserialize :(", e);
+            console.debug("Unable to deserialize :(", e);
         }
     }
 
     let prefix = strPoints.replace(/\d.*/i, "");
-    console.log("Searching for ", prefix, "in", NAMED_PIN_PREFIXES);
+    console.debug("Searching for ", prefix, "in", NAMED_PIN_PREFIXES);
     let pinType = NAMED_PIN_PREFIXES.get(prefix);
     if (pinType != null) {
-        console.log("Creating pin of type", pinType);
+        console.debug("Creating pin of type", pinType);
         let pinHeight = Number.parseInt(strPoints.substring(prefix.length));
         return new JSONPremadePin(pinHeight, PinTypes[pinType]);
     }
-    console.log("Falling back to key pin 5 for ", strPoints);
+    console.debug("Falling back to key pin 5 for ", strPoints);
     return keyPin(5);
 }
 

--- a/models/premadepin.js
+++ b/models/premadepin.js
@@ -18,7 +18,7 @@ export class JSONPremadePin extends Pin {
     }
 
     serialize() {
-        console.log("Serializing ", this);
+        console.debug("Serializing ", this);
         if (this.serializationPrefix) {
             return this.serializationPrefix + this.pinHeight;
         } else {

--- a/simulator/simulator.js
+++ b/simulator/simulator.js
@@ -95,7 +95,7 @@ function getPinBody(pin) {
     const pinBodyBottom = body.bounds.max.y;
     Matter.Body.setPosition(body, {x: body.position.x, y: body.position.y + desiredBottom - pinBodyBottom});
 
-    console.log("Built pin", body, "from vertices", vertices);
+    console.debug("Built pin", body, "from vertices", vertices);
 
     // console.log("Initial body", body);
     // console.log("Vertices", vertices);
@@ -183,7 +183,7 @@ function chamberVertices(innerWidth, outerWidth, height, vertices, openSideUp = 
         points.push({ x: 0, y: height + topPadding + bottomPadding });
         points.push({ x: 0, y: 0 });
     }
-    console.log("Built points for chamber", points);
+    console.debug("Built points for chamber", points);
     return points;
 }
 


### PR DESCRIPTION
Store history in the form of a linked list of serialized chambers. Any change that updates the url also updates the head of the history list to point to the newest serialized chambers. Undoing/redoing moves the current node around in this linked list, loading the chambers from the data at each node.

Added a limit of 20 elements in the history list so it doesn't get out of hand, though if someone creates a truly massive lock, each history entry could be huge. Theoretically we could do this more efficiently by just storing the diff between the new and previous entry in the history list and applying that diff, but I think that's just premature optimization - this approach works fine.

The ability to undo and redo also means if someone accidentally hits `reset`, they can just undo it 😄 