### PR TITLE
Leave space between chambers with countermilling

### DIFF
--- a/models/chamber.js
+++ b/models/chamber.js
@@ -86,8 +86,9 @@ export class Chamber {
     getCorePoints(innerWidth, outerWidth, height) {
         let points = [];
         // First add all points for the left side
-        const outerX = 0;
         const innerX = (outerWidth - innerWidth) / 2;
+        // Add a 15% padding between edge of countermilling and edge of chamber zone
+        const outerX = .15 * innerX;
         switch (this.millingType) {
             case MillingType.Gin:
                 points.push(new Point(innerX, 0));

--- a/models/chamber.js
+++ b/models/chamber.js
@@ -147,8 +147,9 @@ export class Chamber {
 
     getBiblePoints(innerWidth, outerWidth, height) {
         // First add all points for the left side
-        const outerX = 0;
         const innerX = (outerWidth - innerWidth) / 2;
+        // Add a 15% padding between edge of countermilling and edge of chamber zone
+        const outerX = .15 * innerX;
         const points = [];
         switch (this.millingType) {
             case MillingType.Threaded:


### PR DESCRIPTION
Previously, if two chambers with gin milling were next to each other, it'd look like one continuous bar of milling
<img width="266" alt="Screen Shot 2023-10-28 at 10 06 51 PM" src="https://github.com/chestnutzero/pin-planner/assets/1626151/d836cd8f-6487-4805-a8b3-b263e548fba7">

With this change, there's a bit of space to more clearly show the milling
<img width="253" alt="Screen Shot 2023-10-28 at 10 07 30 PM" src="https://github.com/chestnutzero/pin-planner/assets/1626151/bbcf26f2-468b-4879-b615-228b42a2e8f8">
