### PR TITLE
Support modifying chamber and pin types using the dropdowns in the UI

### DIFF
--- a/data/pintypes.js
+++ b/data/pintypes.js
@@ -1,4 +1,4 @@
-export default {
+const data = {
     "KeyPin": {
         "serializationPrefix": "k",
         "points": [
@@ -98,3 +98,11 @@ export default {
         "displayName": "Serrated"
     }
 }
+
+export default Object.fromEntries(Object.entries(data)
+    .map(entry => {
+        const value = entry[1];
+        value.pinTypeOptionValue = entry[0];
+        return [entry[0], value];
+    })
+);

--- a/interface/inputs/chamberinputs.js
+++ b/interface/inputs/chamberinputs.js
@@ -1,4 +1,4 @@
-import { getSelectedChamber, addChamber, deleteChamber, redraw, updateUrl, simulateSelectedChamber } from "../../main.js";
+import { setChamberMillingType, getSelectedChamber, addChamber, deleteChamber, redraw, updateUrl, simulateSelectedChamber } from "../../main.js";
 import PinFactory from "../../models/pinfactory.js";
 import { Chamber, MillingType } from "../../models/chamber.js";
 import Simulator from "../../simulator/simulator.js";
@@ -23,5 +23,13 @@ export function registerChamberListeners() {
 
     document.getElementById("simulate-chamber").addEventListener("click", () => {
         simulateSelectedChamber();
+    });
+
+    millingTypeSelect.addEventListener("change", () => {
+        const selectedChamber = getSelectedChamber();
+        if (selectedChamber) {
+            setChamberMillingType(selectedChamber, millingTypeSelect.value);
+            console.log("Changed chamber", selectedChamber.chamberIdx, "milling type to", millingTypeSelect.value);
+        }
     });
 }

--- a/interface/inputs/inputs.js
+++ b/interface/inputs/inputs.js
@@ -2,10 +2,12 @@ import { registerChamberListeners } from "./chamberinputs.js";
 import { registerResetListener } from "./reset.js";
 import { registerSimulatorInputs } from "./simulatorinputs.js";
 import { addHistoryListeners } from "./historyinputs.js";
+import { addPinTypeListeners } from "./pininputs.js";
 
 export function registerAllListeners() {
     registerChamberListeners();
     registerResetListener();
     registerSimulatorInputs();
     addHistoryListeners();
+    addPinTypeListeners();
 }

--- a/interface/inputs/pininputs.js
+++ b/interface/inputs/pininputs.js
@@ -1,0 +1,12 @@
+import { setPinType, getSelectedPin } from "../../main.js";
+
+const pinTypeSelect = document.getElementById("pin-type");
+
+export function addPinTypeListeners() {
+    pinTypeSelect.addEventListener("change", () => {
+        const selectedPin = getSelectedPin();
+        if (selectedPin) {
+            setPinType(selectedPin, pinTypeSelect.value);
+        }
+    })
+}

--- a/models/premadepin.js
+++ b/models/premadepin.js
@@ -15,6 +15,7 @@ export class JSONPremadePin extends Pin {
         super(points, pinJSON.pinHeight);
         super.setHeight(pinHeight);
         this.serializationPrefix = pinJSON.serializationPrefix;
+        this.pinTypeOptionValue = pinJSON.pinTypeOptionValue;
     }
 
     serialize() {


### PR DESCRIPTION
The `Pin type` and `Chamber milling type` dropdowns can now be used to modify the types of selected pins and chambers respectively.

If you have, for example, `threaded` selected in the milling type dropdown, and then select a chamber, the milling type dropdown will automatically change to whatever the milling type of the selected chamber is. You can change it by selecting values from the dropdown. When you unselect the chamber, it'll go back to `threaded` (the value it was at before you selected a chamber).