### PR TITLE
Allow manually rotating core all the time during simulation

### DIFF
--- a/index.html
+++ b/index.html
@@ -78,7 +78,7 @@
     </div>
     <div id="simulator-controls" hidden>
         <button type="button" id="close-simulator">Exit simulation</button>
-        <label for="mirrored-editor">Lock dragging to vertical only</label>
+        <label for="mirrored-editor">Lock pin dragging to vertical only</label>
         <input type="checkbox" name="lock-drag-controls-vertically" id="lock-drag-controls-vertically" checked>
     </div>
 

--- a/simulator/simulator.js
+++ b/simulator/simulator.js
@@ -221,7 +221,7 @@ function openSimulator(chamber, onCloseCallback = () => {}) {
             yForce = yForce - (bodySpeedY * .01);
 
             let xForce = 0;
-            if (!lockDragControls.checked) {
+            if (!lockDragControls.checked || clickedBody.id === core.id) {
                 xForce = -.001 * ((mouseConstraint.body.position.x + mouseConstraint.constraint.pointB.x) - mouseConstraint.constraint.pointA.x);
                 const bodySpeedX = mouseConstraint.body.velocity.x;
                 xForce = xForce - (bodySpeedX * .01);


### PR DESCRIPTION
Previously, you'd have to uncheck the box that locks dragging to vertical only. Now, you can always manually move the core in any direction by dragging. This allows easy resetting after picking