### PR TITLE
Make horizontal dragging more powerful than vertical in simulator

### DIFF
--- a/simulator/simulator.js
+++ b/simulator/simulator.js
@@ -222,7 +222,7 @@ function openSimulator(chamber, onCloseCallback = () => {}) {
 
             let xForce = 0;
             if (!lockDragControls.checked || clickedBody.id === core.id) {
-                xForce = -.001 * ((mouseConstraint.body.position.x + mouseConstraint.constraint.pointB.x) - mouseConstraint.constraint.pointA.x);
+                xForce = -.01 * ((mouseConstraint.body.position.x + mouseConstraint.constraint.pointB.x) - mouseConstraint.constraint.pointA.x);
                 const bodySpeedX = mouseConstraint.body.velocity.x;
                 xForce = xForce - (bodySpeedX * .01);
             }


### PR DESCRIPTION
This way core rotation using the mouse is more accurate, but pin lifting is still the same level of springiness