### PR TITLE
Encode urls better so that they're linkable in markdown

### DIFF
--- a/interface/urlmanager.js
+++ b/interface/urlmanager.js
@@ -4,10 +4,10 @@ import History from "../data/history.js";
 
 const chambersParam = "c";
 
-function loadFromString(serializedChambers) {
+function loadFromString(crushedChambers) {
     try {
-        console.debug("Raw serialized chambers:", serializedChambers);
-        let rawChambers = JSON.parse(Crusher.uncrush(decodeURIComponent(serializedChambers)));
+        console.debug("Raw serialized chambers:", crushedChambers);
+        let rawChambers = JSON.parse(Crusher.uncrush(crushedChambers));
         console.debug("Raw chambers: " + rawChambers);
         let chamberIdx = 0;
         let result = [];
@@ -28,7 +28,7 @@ function loadFromString(serializedChambers) {
         console.log("Loaded chambers", result);
         return result;
     } catch (e) {
-        console.debug("Malformed query param", e);
+        console.log("Malformed query param", e);
         return [];
     }
 }
@@ -43,18 +43,26 @@ function loadFromUrlParams() {
 }
 
 function updateUrlParams(chambers) {
-    let serializedChambers = encodeURIComponent(Crusher.crush(JSON.stringify(chambers.map(c => c.serialize()))));
+    const crushedChambers = Crusher.crush(JSON.stringify(chambers.map(c => c.serialize())));
+    const serializedChambers = encode(crushedChambers);
     let newUrl = window.location.origin + window.location.pathname + "?c=" + serializedChambers;
+    console.debug("Updating url to", newUrl);
     window.history.replaceState({path:newUrl}, "", newUrl);
-    History.updateCurrentData(serializedChambers);
+    History.updateCurrentData(crushedChambers);
 }
 
 /**
  * Used to update the url params in the browser after moving around in history
  */
-function updateUrlParamsRaw(serializedChambers) {
-    let newUrl = window.location.origin + window.location.pathname + "?c=" + serializedChambers;
+function updateUrlParamsRaw(crushedChambers) {
+    let newUrl = window.location.origin + window.location.pathname + "?c=" + encode(crushedChambers);
     window.history.replaceState({path:newUrl}, "", newUrl);
+}
+
+function encode(str) {
+    return encodeURIComponent(str).replace(/[_!'()*]/g, function(c) {
+        return '%' + c.charCodeAt(0).toString(16);
+      });
 }
 
 export default {updateUrlParamsRaw, loadFromUrlParams, updateUrlParams, loadFromString};


### PR DESCRIPTION
Incomplete encoding was messing up the ability to link urls in markdown

e.g.

https://chestnutzero.github.io/pin-planner/?c=%5B%27IAk4xc9GgZ9xd9v~IAk5xsr7GtUV-J3086_V4_OJOJ8Vq_zP6lDDT335DDazK8VqKOaOaV4K3086K1V-E6B7)NC.1--PFQJQLQE9FQE9B6)GgUu3-J5517E0741q548E0741Fl05fl51f7245J7261J7894P343F794fXJXJ9005P412yP43w9514J94uL94uT5lF9514T588yK9005KXjXTl7F794K7894K7261j7245jl51E9259Fl05E9259q548K5517K1u3-E6B6)NC--JRPwRPwSJSLSTwSTwRKR*1B7)GbZ7xs7v%5D*W%5B-%2C0A%5C%27B--%5DWMApinHeightMYCA(MApointsMY%5B%5B0D%2C1E*0.F-.GAWAmYAI(ApY%5BJ*0FK*1FL*0DD*1DDKM%5C%5Cx%2COu43qPE1Q6667DR0286-S9714DTE8UA)%27~IC.4--J1V571W%5D%2CX8449Y%5C!ZA)%27~%5BAk_P801FaT199FfP366FjT634Fl65qF5u83vA%5D%27w5FxNAyF9035z8857q%01zyxwvuqljfa_ZYXWVUTSRQPONMLKJIGFEDCBA-*_

[link](https://chestnutzero.github.io/pin-planner/?c=%5B%27IAk4xc9GgZ9xd9v~IAk5xsr7GtUV-J3086_V4_OJOJ8Vq_zP6lDDT335DDazK8VqKOaOaV4K3086K1V-E6B7)NC.1--PFQJQLQE9FQE9B6)GgUu3-J5517E0741q548E0741Fl05fl51f7245J7261J7894P343F794fXJXJ9005P412yP43w9514J94uL94uT5lF9514T588yK9005KXjXTl7F794K7894K7261j7245jl51E9259Fl05E9259q548K5517K1u3-E6B6)NC--JRPwRPwSJSLSTwSTwRKR*1B7)GbZ7xs7v%5D*W%5B-%2C0A%5C%27B--%5DWMApinHeightMYCA(MApointsMY%5B%5B0D%2C1E*0.F-.GAWAmYAI(ApY%5BJ*0FK*1FL*0DD*1DDKM%5C%5Cx%2COu43qPE1Q6667DR0286-S9714DTE8UA)%27~IC.4--J1V571W%5D%2CX8449Y%5C!ZA)%27~%5BAk_P801FaT199FfP366FjT634Fl65qF5u83vA%5D%27w5FxNAyF9035z8857q%01zyxwvuqljfa_ZYXWVUTSRQPONMLKJIGFEDCBA-*_)