### PR TITLE
Add support for touch controls

### DIFF
--- a/interface/pineditor.js
+++ b/interface/pineditor.js
@@ -223,6 +223,10 @@ function handleMouseDrag(event) {
     const normalizedMouseX = Math.min(Math.max((mouseCoords[0] - pinRect.x) / pinRect.width, 0), 1);
     const normalizedMouseY = Math.min(Math.max((mouseCoords[1] - pinRect.y) / pinRect.height, 0), 1);
 
+    if (selectedNormalizedPoint || selectedMirroredPointIdx) {
+        event.preventDefault();
+    }
+
     if (selectedNormalizedPoint) {
         currentPin.points[selectedPointIdx].x = normalizedMouseX;
         currentPin.points[selectedPointIdx].y = normalizedMouseY;

--- a/main.js
+++ b/main.js
@@ -157,6 +157,7 @@ function resetPinSelection() {
 
 function handleClick(event) {
     if (Simulator.isOpen()) {
+        console.log("ignoring click because simulator is open");
         return;
     }
     console.debug("click");
@@ -249,27 +250,61 @@ canvas.addEventListener("mousemove", event => {
         }
     } else {
         if (mouseDown) {
-            if (dragging && selectedPin) {
-                let canvasBounds = canvas.getBoundingClientRect();
-                const mouseX = event.clientX - canvasBounds.left;
-                const mouseY = canvasBounds.height - (event.clientY - canvasBounds.top);
-                redraw();
-                ctx.fillStyle = "#aaae";
-                drawPin(selectedPin, mouseX - 25, mouseY, 50, 50 * selectedPin.pinHeight / chamberHeightToWidthRatio, false);
-            } else if (!dragging) {
-                // Make sure clicks don't register as drags
-                if (Math.max(Math.abs(event.clientX - mouseDownX), Math.abs(event.clientY - mouseDownY) > 10)) {
-                    // Autoselect pin under mouse when a drag event starts
-                    resetPinSelection();
-                    handleClick(event);
-                    dragging = true;
-                }
-            }
+            handleMouseDrag(event);
         }
     }
 });
 
+canvas.addEventListener("touchmove", event => {
+    if (event.touches.length == 1) {
+        event = shimTouchEvent(event);
+        console.log("touch move event", event);
+    }
+    if (Simulator.isOpen()) {
+        return;
+    }
+    if (PinEditor.isPinEditorOpen()) {
+            PinEditor.handleMouseDrag(event);
+    } else {
+        handleMouseDrag(event);
+    }
+});
+
+function handleMouseDrag(event) {
+    if (dragging && selectedPin) {
+        event.preventDefault();
+        let canvasBounds = canvas.getBoundingClientRect();
+        const mouseX = event.clientX - canvasBounds.left;
+        const mouseY = canvasBounds.height - (event.clientY - canvasBounds.top);
+        redraw();
+        ctx.fillStyle = "#aaae";
+        drawPin(selectedPin, mouseX - 25, mouseY, 50, 50 * selectedPin.pinHeight / chamberHeightToWidthRatio, false);
+    } else if (!dragging) {
+        console.log("Starting dragging");
+        // Make sure clicks don't register as drags
+        if (Math.max(Math.abs(event.clientX - mouseDownX), Math.abs(event.clientY - mouseDownY) > 10)) {
+            // Autoselect pin under mouse when a drag event starts
+            resetPinSelection();
+            handleClick(event);
+            if (selectedPin) {
+                event.preventDefault();
+            }
+            dragging = true;
+        }
+    }
+}
+
 canvas.addEventListener("mousedown", event => {
+    handleMouseDown(event);
+});
+canvas.addEventListener("touchstart", event => {
+    if (event.touches.length == 1) {
+        console.log("touch event", event);
+        handleMouseDown(shimTouchEvent(event));
+    }
+});
+function handleMouseDown(event) {
+    event.preventDefault();
     if (Simulator.isOpen()) {
         return;
     }
@@ -279,8 +314,21 @@ canvas.addEventListener("mousedown", event => {
     if (PinEditor.isPinEditorOpen()) {
         PinEditor.handleMouseDown(event);
     }
-});
+}
+
 canvas.addEventListener("mouseup", event => {
+    handleMouseUp(event);
+});
+canvas.addEventListener("touchend", event => {
+    if (event.touches.length == 0 && event.changedTouches.length == 1) {
+        event = shimTouchEvent(event);
+        console.log("touch ended", event);
+        handleMouseUp(event);
+        handleClick(event);
+    }
+});
+function handleMouseUp(event) {
+    event.preventDefault();
     if (Simulator.isOpen()) {
         return;
     }
@@ -289,7 +337,7 @@ canvas.addEventListener("mouseup", event => {
     if (PinEditor.isPinEditorOpen()) {
         PinEditor.handleMouseUp(event);
     }
-});
+}
 
 document.getElementById("edit-pin").addEventListener("click", () => {
     if (selectedPin && !PinEditor.isPinEditorOpen()) {
@@ -419,6 +467,19 @@ export function simulateSelectedChamber() {
             redraw();
         });
     }
+}
+
+// Pick one of the touches as the clientX and clientY to use
+// We don't support multitouch
+function shimTouchEvent(event) {
+    if (event.touches.length > 0) {
+        event.clientX = event.touches[0].clientX;
+        event.clientY = event.touches[0].clientY;
+    } else if (event.changedTouches.length > 0) {
+        event.clientX = event.changedTouches[0].clientX;
+        event.clientY = event.changedTouches[0].clientY;
+    }
+    return event;
 }
 
 chambers = UrlManager.loadFromUrlParams();

--- a/main.js
+++ b/main.js
@@ -258,7 +258,6 @@ canvas.addEventListener("mousemove", event => {
 canvas.addEventListener("touchmove", event => {
     if (event.touches.length == 1) {
         event = shimTouchEvent(event);
-        console.log("touch move event", event);
     }
     if (Simulator.isOpen()) {
         return;
@@ -299,7 +298,6 @@ canvas.addEventListener("mousedown", event => {
 });
 canvas.addEventListener("touchstart", event => {
     if (event.touches.length == 1) {
-        console.log("touch event", event);
         handleMouseDown(shimTouchEvent(event));
     }
 });
@@ -322,7 +320,6 @@ canvas.addEventListener("mouseup", event => {
 canvas.addEventListener("touchend", event => {
     if (event.touches.length == 0 && event.changedTouches.length == 1) {
         event = shimTouchEvent(event);
-        console.log("touch ended", event);
         handleMouseUp(event);
         handleClick(event);
     }


### PR DESCRIPTION
Things that work:
 - Dragging pins to move them between chambers
 - Tapping a point in in the pin editor to select it, then dragging it to move it around
 - Normal drag controls in the simulator
 - Dragging on canvas no longer results in scrolling