### PR TITLE
Improve simulator physics stability

### DIFF
--- a/main.js
+++ b/main.js
@@ -461,6 +461,7 @@ export function simulateSelectedChamber() {
         Simulator.openSimulator(selectedChamber, () => {
             plannerOpts.removeAttribute("hidden")
             simulatorControls.setAttribute("hidden", true);
+            resetPinSelection();
             redraw();
         });
     }

--- a/models/chamber.js
+++ b/models/chamber.js
@@ -124,10 +124,11 @@ export class Chamber {
                 break;
             case MillingType.Threaded:
                 let inner = true;
-                for (let h = 0; h<=height; h+=height * .04) {
+                for (let h = 0; h<height; h+=height * .04) {
                     points.push(new Point(inner ? innerX : outerX, h));
                     inner = !inner;
                 }
+                points.push(new Point(inner ? innerX : outerX, height));
                 break;
             case MillingType.None:
             default:


### PR DESCRIPTION
Turns out I was running my own `requestAnimationFrame`-based loop for updating the physics engine, and ALSO was using matter.js' built-in `Runner` that does the exact same thing. The result was that the two were both updating the engine way too frequently and causing jitter and instability. This also caused the engine to miss more collisions too, for some reason. With this change, physics stability is much better. I also did a little work to make the springs behave more reliably by scaling the pin and chambers' density with size so they have a consistent mass and inertia.